### PR TITLE
Use NXDK new build system

### DIFF
--- a/.github/workflows/xbox.yml
+++ b/.github/workflows/xbox.yml
@@ -13,20 +13,20 @@ jobs:
     steps:
     - name: Install and Setup Dependencies
       run: |
-        sudo apt-get update -y && sudo apt-get install -y flex bison clang lld
+        sudo apt-get update -y && sudo apt-get install -y flex bison clang lld llvm
         cd ~
-        git clone https://github.com/XboxDev/nxdk.git --recursive
- 
+        git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/XboxDev/nxdk.git
+
     - name: Checkout Repository
       uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: recursive
 
     - name: Compile
+      working-directory: example
       run: |
-        export PATH=$PATH:/usr/lib/llvm-10/bin
-        cd example/
-        make -f Makefile.nxdk -j$(nproc) NXDK_DIR=~/nxdk
+        eval $(~/nxdk/bin/activate -s)
+        make -f Makefile.nxdk -j$(nproc)
 
     # Only create artifact on a push to master
     - if: github.event_name == 'push' 


### PR DESCRIPTION
NXDK's new build system require `NXDK_DIR` to be create in environment variable than local variable in order for it to work. Past method will no longer work properly according to GitHub CI's build failure in clean slate.