### PR TITLE
Quick fix for mouse

### DIFF
--- a/example/example.c
+++ b/example/example.c
@@ -64,6 +64,10 @@ void lv_demo_keypad_encoder(void)
         if(cur_drv->driver->type == LV_INDEV_TYPE_ENCODER) {
             lv_indev_set_group(cur_drv, g);
         }
+
+        if(cur_drv->driver->type == LV_INDEV_TYPE_POINTER) {
+            lv_indev_set_group(cur_drv, g);
+        }
     }
 
     tv = lv_tabview_create(lv_scr_act(), LV_DIR_TOP, LV_DPI_DEF / 3);
@@ -206,7 +210,7 @@ static void ta_event_cb(lv_event_t * e)
     lv_obj_t * ta = lv_event_get_target(e);
     lv_obj_t * kb = lv_event_get_user_data(e);
 
-    if(code == LV_EVENT_CLICKED && indev_type == LV_INDEV_TYPE_ENCODER) {
+    if(code == LV_EVENT_CLICKED && ((indev_type == LV_INDEV_TYPE_ENCODER)||(indev_type == LV_INDEV_TYPE_POINTER))) {
         lv_keyboard_set_textarea(kb, ta);
         lv_obj_clear_flag(kb, LV_OBJ_FLAG_HIDDEN);
         lv_group_focus_obj(kb);

--- a/lvgl_drv/lv_port_indev.c
+++ b/lvgl_drv/lv_port_indev.c
@@ -77,11 +77,6 @@ void lv_set_quit(lv_quit_event_t event)
 
 static void mouse_read(lv_indev_drv_t *indev_drv_gamepad, lv_indev_data_t *data)
 {
-    if (pad == NULL)
-    {
-        return;
-    }
-
     data->state = (mouse_pressed) ? LV_INDEV_STATE_PRESSED : LV_INDEV_STATE_RELEASED;
 
     // Event for a USB mouse
@@ -96,6 +91,11 @@ static void mouse_read(lv_indev_drv_t *indev_drv_gamepad, lv_indev_data_t *data)
     // From gamecontroller
     else
     {
+        if (pad == NULL)
+        {
+            return;
+        }
+
         int x = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTX);
         int y = SDL_GameControllerGetAxis(pad, SDL_CONTROLLER_AXIS_LEFTY);
 


### PR DESCRIPTION
This is a quick fix for mouse. The mouse didn't work because the code checked for the presence of a game pad/controller (lines 80-83) regardless of the connected device. Not finding the pad, the code was exiting the function. I moved this code snippet to the game controller-related section and now the mouse works.
I've forked this code and I propose to merge my changes back into your repository.
Regards,
Chris